### PR TITLE
Issue#12 fix, ensure 1.x version SlackClient installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-SlackClient
+SlackClient<2.0.0
 defang
 pymisp
 pyjokes


### PR DESCRIPTION
Simply ensures something less than SlackClient 2.0.0 is installed, should resolve immediate issues, though would still be better to upgrade code to use SlackClient 2.x